### PR TITLE
Fix missing pandas import in video processing route

### DIFF
--- a/backend/app/video_processing_route.py
+++ b/backend/app/video_processing_route.py
@@ -8,6 +8,7 @@ import shutil
 from pathlib import Path
 import uuid
 import time
+import pandas as pd
 
 # Import the processing functions
 from movenet_extraction import process_video_file


### PR DESCRIPTION
## Summary
- add missing pandas import for video_processing_route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'backend')*
